### PR TITLE
Fix env loading in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,10 @@
 set -e
 
 echo "run db migration"
-source /app/app.env
+# Load environment variables if they are not already set
+if [ -z "$DB_SOURCE" ]; then
+  . /app/app.env
+fi
 migrate -path /app/migration -database "$DB_SOURCE" -verbose up   # ← use “migrate”, not “/app/migrate”
 
 echo "start the app"


### PR DESCRIPTION
## Summary
- only source app.env if DB_SOURCE is not set

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852e8e9ad908324bde6f87a6e6b7730